### PR TITLE
[Fix][Name Node] Use Query Params in Search endpoint

### DIFF
--- a/data_node/controllers/outer/upload_controller.go
+++ b/data_node/controllers/outer/upload_controller.go
@@ -46,7 +46,7 @@ func (server *Server) handleInitialUpload(w http.ResponseWriter, r *http.Request
 	log.Println(ucLogPrefix, r.RemoteAddr, "Received init request")
 
 	expectedHeaders := []string{"Filename", "Filesize", "Filetype"}
-	err := validateUploadHeaders(&r.Header, expectedHeaders...)
+	err := requests.ValidateHeaders(&r.Header, expectedHeaders...)
 
 	if err != nil {
 		log.Println(ucLogPrefix, r.RemoteAddr, err)
@@ -72,7 +72,7 @@ func (server *Server) handleInitialUpload(w http.ResponseWriter, r *http.Request
 // handleModelInitialUpload is responsible for handling upload request for model file
 func (server *Server) handleModelInitialUpload(w http.ResponseWriter, r *http.Request) {
 	expectedHeaders := []string{"Model-Size", "Config-Size", "Code-Size"}
-	err := validateUploadHeaders(&r.Header, expectedHeaders...)
+	err := requests.ValidateHeaders(&r.Header, expectedHeaders...)
 	if err != nil {
 		log.Println(ucLogPrefix, r.RemoteAddr, err)
 		handleRequestError(w, http.StatusBadRequest, err.Error())
@@ -286,7 +286,7 @@ func (server *Server) handleAppendUpload(w http.ResponseWriter, r *http.Request)
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 
 	expectedHeaders := []string{"Offset", "ID"}
-	err := requests.ValidateUploadHeaders(&r.Header, expectedHeaders...)
+	err := requests.ValidateHeaders(&r.Header, expectedHeaders...)
 	if err != nil {
 		log.Println(ucLogPrefix, r.RemoteAddr, err)
 		requests.HandleRequestError(w, http.StatusBadRequest, err.Error())

--- a/name_node/controllers/outer/search_request_controller.go
+++ b/name_node/controllers/outer/search_request_controller.go
@@ -77,7 +77,7 @@ func retrieveClips(params ...interface{}) []namenode.Clip {
 	if len(params) == 1 {
 		namenode.NodeInstance().DB.Connection.Where("tag = ?", params[0]).Find(&clips)
 	} else {
-		namenode.NodeInstance().DB.Connection.Where("tag = ? and start_time >= ? and end_time <= ?",
+		namenode.NodeInstance().DB.Connection.Where("tag = ? and start_time >= ? and start_time <= ?",
 			params[0], params[1], params[2]).Find(&clips)
 	}
 

--- a/name_node/controllers/outer/search_request_controller.go
+++ b/name_node/controllers/outer/search_request_controller.go
@@ -20,10 +20,10 @@ func (server *Server) SearchRequestHandler(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("content-type", "application/json")
 
-	expectedHeaders := []string{"Tag"}
-	optionalHeaders := []string{"StartTime", "EndTime"}
+	expectedParams := []string{"tag"}
+	optionalParams := []string{"start", "end"}
 
-	err := requests.ValidateUploadHeaders(&r.Header, expectedHeaders...)
+	err := requests.ValidateQuery(r.URL.Query(), expectedParams...)
 	if errors.IsError(err) {
 		log.Println(scLogPrefix, r.RemoteAddr, err)
 		requests.HandleRequestError(w, http.StatusBadRequest, err.Error())
@@ -33,12 +33,12 @@ func (server *Server) SearchRequestHandler(w http.ResponseWriter, r *http.Reques
 
 	var clips []namenode.Clip
 
-	tag := r.Header.Get("Tag")
+	tag := r.URL.Query().Get("tag")
 
-	err = requests.ValidateUploadHeaders(&r.Header, optionalHeaders...)
+	err = requests.ValidateQuery(r.URL.Query(), optionalParams...)
 	if !errors.IsError(err) {
-		start, startErr := strconv.ParseUint(r.Header.Get("StartTime"), 10, 64)
-		end, endErr := strconv.ParseUint(r.Header.Get("EndTime"), 10, 64)
+		start, startErr := strconv.ParseUint(r.URL.Query().Get("start"), 10, 64)
+		end, endErr := strconv.ParseUint(r.URL.Query().Get("end"), 10, 64)
 
 		if errors.IsError(startErr) || errors.IsError(endErr) {
 			log.Println(scLogPrefix, r.RemoteAddr, "Error while parsing start or end times")

--- a/name_node/controllers/outer/search_request_controller.go
+++ b/name_node/controllers/outer/search_request_controller.go
@@ -14,6 +14,13 @@ import (
 
 var scLogPrefix = "[Search-Controller]"
 
+// searchResult Represents the result payload of the search endpoint
+type searchResult struct {
+	Tag   string `json:"tag"`
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
 // SearchRequestHandler Handles client's search request
 func (server *Server) SearchRequestHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	log.Println(scLogPrefix, "Received search request")
@@ -59,7 +66,7 @@ func (server *Server) SearchRequestHandler(w http.ResponseWriter, r *http.Reques
 		clips = retrieveClips(tag)
 	}
 
-	resp, err := json.Marshal(clips)
+	resp, err := json.Marshal(decorate(clips))
 	if errors.IsError(err) {
 		log.Println(scLogPrefix, r.RemoteAddr, err)
 		requests.HandleRequestError(w, http.StatusInternalServerError, err.Error())
@@ -82,4 +89,15 @@ func retrieveClips(params ...interface{}) []namenode.Clip {
 	}
 
 	return clips
+}
+
+// decorate A function to decorate the search result for web
+func decorate(clips []namenode.Clip) []searchResult {
+	var result []searchResult
+
+	for _, clip := range clips {
+		result = append(result, searchResult{Tag: clip.Tag, Start: clip.StartTime, End: clip.EndTime})
+	}
+
+	return result
 }

--- a/utils/requests/requests.go
+++ b/utils/requests/requests.go
@@ -16,8 +16,8 @@ func HandleRequestError(w http.ResponseWriter, statusCode int, message string) {
 	fmt.Fprintf(w, FormatMessage("error", message))
 }
 
-// ValidateUploadHeaders is a function to check existance of parameters inside header
-func ValidateUploadHeaders(h *http.Header, params ...string) error {
+// ValidateHeaders is a function to check existance of parameters inside header
+func ValidateHeaders(h *http.Header, params ...string) error {
 	for _, param := range params {
 		if h.Get(param) == "" {
 			return errors.New(fmt.Sprintf("%s header not provided", param))

--- a/utils/requests/requests.go
+++ b/utils/requests/requests.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/SayedAlesawy/Videra-Storage/utils/errors"
 )
@@ -21,6 +22,17 @@ func ValidateHeaders(h *http.Header, params ...string) error {
 	for _, param := range params {
 		if h.Get(param) == "" {
 			return errors.New(fmt.Sprintf("%s header not provided", param))
+		}
+	}
+
+	return nil
+}
+
+// ValidateQuery A function to validate the existence of params inside the query string
+func ValidateQuery(query url.Values, params ...string) error {
+	for _, param := range params {
+		if query.Get(param) == "" {
+			return errors.New(fmt.Sprintf("%s query param not provided", param))
 		}
 	}
 


### PR DESCRIPTION
Use query params instead of headers in search endpoint.
Example:
```
GET /search?tag=tag1&start=1&end=6
```
Result:
```
[
    {
        "tag": "tag1",
        "start": 2,
        "end": 4
    },
    {
        "tag": "tag1",
        "start": 2,
        "end": 5
    },
    {
        "tag": "tag1",
        "start": 3,
        "end": 6
    },
    {
        "tag": "tag1",
        "start": 1,
        "end": 1
    }
]
```